### PR TITLE
Add SkilLock under Tools & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Security tools for testing and defending AI systems against adversarial attacks.
 - [SecML](https://secml.readthedocs.io/) - Secure and explainable ML library with attacks and defenses.
 - [Purple Llama (Meta)](https://github.com/meta-llama/PurpleLlama) - Open-source LLM safety tools including Llama Guard, Prompt Guard, Code Shield, and CyberSec Eval benchmarks.
 - [ai-evaluation](https://github.com/future-agi/ai-evaluation) - Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners (jailbreak, PII, prompt-injection) for systematic AI security testing.
+- [SkilLock](https://github.com/skills-lock/skil-lock) - Behavior-pinning lockfile and capability-delta PR review for Claude Code and Codex agent skills; blocks unapproved drift (shell, network, file access) in CI with SARIF output for Code Scanning.
 
 ### AI Pentesting
 Using AI assistants and agents for automated penetration testing and security assessments.


### PR DESCRIPTION
Adds **SkilLock** to the Tools & Frameworks section.

SkilLock is an open-source (Apache-2.0) CLI + GitHub Action that pins approved AI agent **skill behavior** (Claude Code / Codex SKILL.md) in a committed `skills.lock` and blocks unapproved capability drift — shell execution, external network, protected-path access — in CI, with a capability-delta PR comment and SARIF output for Code Scanning.

- Repo: https://github.com/skills-lock/skil-lock
- Distinct from hash-pinning tools: it pins *behavior* and surfaces the security delta for human review on each PR.

Single-line addition; entry follows the section's existing format.