### PR TITLE
Add SecuredAI to Tools & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Awesome AI Security
 
 A curated, annotated list of resources for AI security.
@@ -85,6 +86,7 @@ Security tools for testing and defending AI systems against adversarial attacks.
 - [Agent-Wiz](https://github.com/Repello-AI/Agent-Wiz) - Repello AI's open-source CLI that extracts agentic workflows from LangChain/LangGraph/CrewAI/AutoGen and runs automated threat modeling against the resulting graphs.
 - [ai-evaluation](https://github.com/future-agi/ai-evaluation) - Open-source LLM evaluation framework with 50+ metrics, LLM-as-Judge, and guardrail scanners (jailbreak, PII, prompt-injection) for systematic AI security testing.
 - [SkilLock](https://github.com/skills-lock/skil-lock) - Behavior-pinning lockfile and capability-delta PR review for Claude Code and Codex agent skills; blocks unapproved drift (shell, network, file access) in CI with SARIF output for Code Scanning.
+- [SecuredAI](https://securedai.com/) - Client-side prompt DLP that detects and masks PII/PHI before prompts reach the model (OpenAI/DeepSeek), restoring the originals locally via a zero-knowledge vault.
 
 ### AI Pentesting
 Using AI assistants and agents for automated penetration testing and security assessments.


### PR DESCRIPTION
Adds **SecuredAI** (https://securedai.com) to *Tools & Frameworks*.

A defensive tool: client-side prompt DLP that detects and masks PII/PHI before prompts reach the model (OpenAI/DeepSeek), then restores originals locally via a zero-knowledge vault. Sits alongside the existing guardrail/defense entries (NeMo Guardrails, Purple Llama); commercial, like APort already on the list.

Single-line addition, format matches the section. Thanks for the list.